### PR TITLE
fix: invalid components.json

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,14 +1,14 @@
 {
-	"$schema": "https://shadcn-svelte.com/schema.json",
-	"style": "default",
-	"tailwind": {
-		"config": "tailwind.config.js",
-		"css": "src\\app.css",
-		"baseColor": "slate"
-	},
-	"aliases": {
-		"components": "$lib/components",
-		"utils": "$lib/utils"
-	},
-	"typescript": true
+  "$schema": "https://shadcn-svelte.com/schema.json",
+  "style": "default",
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/app.css",
+    "baseColor": "slate"
+  },
+  "aliases": {
+    "components": "$lib/components",
+    "utils": "$lib/utils"
+  },
+  "typescript": true
 }


### PR DESCRIPTION
Copilot Gen:
This pull request includes a small change to the `components.json` file. The change corrects the file path for the `css` property to use forward slashes instead of backslashes.

* [`components.json`](diffhunk://#diff-2c9eb56f775dd960fa3fb60253b2d30f21baae2e81f352e63a0984f129408016L6-R6): Corrected the `css` property file path from `src\app.css` to `src/app.css`.