### PR TITLE
chore: alias to form schemas

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,14 +1,14 @@
 {
-	"$schema": "https://shadcn-svelte.com/schema.json",
-	"style": "default",
-	"tailwind": {
-		"config": "tailwind.config.js",
-		"css": "src\\app.css",
-		"baseColor": "slate"
-	},
-	"aliases": {
-		"components": "$lib/components",
-		"utils": "$lib/utils"
-	},
-	"typescript": true
+  "$schema": "https://shadcn-svelte.com/schema.json",
+  "style": "default",
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/app.css",
+    "baseColor": "slate"
+  },
+  "aliases": {
+    "components": "$lib/components",
+    "utils": "$lib/utils"
+  },
+  "typescript": true
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,7 +11,11 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter(),
+
+		alias: {
+			"$form": "./src/shared-components/form"
+		}
 	}
 };
 


### PR DESCRIPTION
*Note: this is a branch from `invalid components.json`.

Optional and opinionated.

Copilot Gen:

This pull request includes changes to `components.json` and `svelte.config.js` to fix a minor formatting issue and add an alias for shared components.

Configuration and formatting improvements:

* [`components.json`](diffhunk://#diff-2c9eb56f775dd960fa3fb60253b2d30f21baae2e81f352e63a0984f129408016L6-R6): Fixed the path formatting for the `css` property in the `tailwind` configuration.

Alias addition:

* [`svelte.config.js`](diffhunk://#diff-6317e218ea40a2a9b47af98e100e81c06f9c0abff66737e6ca06ec4b29402242L14-R18): Added an alias for the `form` component to simplify imports.